### PR TITLE
protect gql route, but allow for now all origins for CORS

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 import os
 # flask-peewee bindings
 from flask_peewee.db import Database
+from flask_cors import CORS
 
 
 load_dotenv()
@@ -12,6 +13,7 @@ API_AUDIENCE = os.getenv('AUTH0_AUDIENCE')
 ALGORITHMS = ["RS256"]
 
 app = Flask(__name__)
+CORS(app)
 
 app.config['DATABASE'] = {
     "name": os.getenv("MYSQL_DB"),

--- a/routes.py
+++ b/routes.py
@@ -58,6 +58,8 @@ def graphql_playgroud():
 
 
 @app.route("/graphql", methods=["POST"])
+@cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])
+@requires_auth
 def graphql_server():
     # GraphQL queries are always sent as POST
     data = request.get_json()


### PR DESCRIPTION
goes with https://github.com/boxwise/boxwise-react/pull/7
in this, I'm just protecting the gql endpoint and enabling all origins for now. 
PLEASE NOTE: protecting the gql endpoint means you will need to obtain an access token from auth0 to be able to use the playground. You can do that via the react app, or likely on auth0 itself.
![Screenshot 2020-06-04 at 18 03 56](https://user-images.githubusercontent.com/5653631/83785458-9ea05d80-a691-11ea-98e7-be4b40ad0980.png)
