### PR TITLE
Enable flask debug mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,7 @@ FROM python:3.8-slim-buster
 RUN mkdir /code
 WORKDIR /code
 ENV FLASK_APP main
-ENV FLASK_RUN_HOST 127.0.0.1:5000
-COPY requirements.txt requirements.txt
-RUN apt-get update -y && apt-get install -y python3-pip python3-dev && \
-    apt-get install -y libmariadb-dev python3-dev && pip install -r requirements.txt
-COPY . .
-#CMD ["flask","run"]
+RUN apt-get update -y && apt-get install -y libmariadb-dev
+COPY requirements.txt .
+RUN pip install -r requirements.txt && rm requirements.txt
 CMD flask run --host=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim-buster
-RUN mkdir /code
-WORKDIR /code
+RUN mkdir /codedir
+WORKDIR /codedir
 ENV FLASK_APP main
 RUN apt-get update -y && apt-get install -y libmariadb-dev
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ This project is developed in Python >= 3.6. For setting up the development envir
 
 Now you're all set up using Python code quality tools! `pre-commit´ automatically checks the staged patch before committing. If it rejects a patch, add the corrections and try to commit again.
 
+#### Formatting and linting
+
 Run a full style-check by
 
     pre-commit run --all-files
 
-#### Formatting
+#### Debugging
 
-Right now we are using Black for formatting. To format a file, use `black {source_file_or_directory}`. Auto-formatting to be implemented later. 
+By default the flask app runs in `development` mode which has hot-reloading and debugging enabled.
+
+For debugging an exception in an endpoint, direct your webbrowser to that endpoint. The built-in flask debugger is shown. You can attach a console by clicking the icons on the right of the traceback lines. For more information, refer to the [documentation](https://flask.palletsprojects.com/en/1.1.x/quickstart/#debug-mode).
 
 #### GraphQL
 We are setting up GraphQL as a data layer for this application. To check out the playground, run this project with the above docker-compose instructions, and go to localhost:5000/graphql. A sample query you can try is:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
           - backend
         volumes:
           - .:/codedir
-        # environment:
-          # TODO: debug mode: ON crashes flask in docker-compose up 
-          # FLASK_ENV: development
+        environment:
+          FLASK_ENV: development
     mysql:
         image: mysql/mysql-server:latest
         command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ click==7.1.2
 ecdsa==0.15
 Flask==1.1.2
 Flask-Cors==3.0.8
-Flask-MySQLdb==0.2.0
 flask-peewee==3.0.3
 graphql-core==3.0.4
 itsdangerous==1.1.0

--- a/routes.py
+++ b/routes.py
@@ -4,7 +4,6 @@ from flask import Flask, request, jsonify, _request_ctx_stack
 import json
 from flask_cors import cross_origin
 from jose import jwt
-from flask_mysqldb import MySQL
 from dotenv import load_dotenv
 import os
 


### PR DESCRIPTION
- hot-reloading of the flask app is now possible: When the app is already up and running, changes in the source code will be detected.
- debugging is possible by using the built-in debugger. For trying out, add a `raise Exception` at the beginning of the `/`-route, and direct your browser to `http://0.0.0.0:5000`. You can attach a console by clicking the icons on the right of the traceback lines. I tried to run `pdb` but flask did not seem to like it.
- cleaned up the flask Dockerfile a little
