### PR TITLE
Circleci/add frontend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
               MYSQL_DB=${DB_NAME}
               MYSQL_SOCKET=${DB_SOCKET}
               FLASK_STATIC_FOLDER=../react
-              FLASK_STATIC_URL_PATH=/mobile" > .env"
+              FLASK_STATIC_URL_PATH=/mobile" > .env
       - run:
           name: Generate GAE app.yaml file
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: |
             echo "
               REACT_APP_AUTH0_DOMAIN=${AUTH0_DOMAIN}
-              REACT_APP_AUTH0_CLIENT_ID=${REACT_APP_AUTH0_CLIENT_ID}
+              REACT_APP_AUTH0_CLIENT_ID=${AUTH0_CLIENT_ID}
               REACT_APP_AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
               REACT_APP_REDIRECT=${REACT_APP_REDIRECT}
               REACT_APP_LOGOUT_URL=${REACT_APP_LOGOUT_URL}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
               REACT_APP_REDIRECT=${REACT_APP_REDIRECT}
               REACT_APP_LOGOUT_URL=${REACT_APP_LOGOUT_URL}
               REACT_APP_GRAPHQL_SERVER=${REACT_APP_GRAPHQL_SERVER}" > .env
+      - run:
+          name: Set hompage in package.json
+          command: |
+            sed -i 's|"homepage": "http://localhost:3000/"|"homepage": "https://'$URL'/mobile"|' package.json
       # following https://circleci.com/docs/2.0/yarn/
       - restore_cache:
           name: Restore Yarn Package Cache
@@ -125,7 +129,7 @@ jobs:
               Branch: ${CIRCLE_BRANCH}
               Git hash: ${CIRCLE_SHA1}" > version.txt
       - run:
-          name: Generate .env file
+          name: Generate .env files
           command: |
             echo "
               AUTH0_DOMAIN=${AUTH0_DOMAIN}
@@ -133,7 +137,9 @@ jobs:
               MYSQL_USER=${DB_NAME}
               MYSQL_PASSWORD=${DB_PASS}
               MYSQL_DB=${DB_NAME}
-              GCLOUD_SQL_CONNECTION_NAME=${GCLOUD_SQL_CONNECTION_NAME}" > .env
+              MYSQL_SOCKET=${DB_SOCKET}
+              FLASK_STATIC_FOLDER=../react
+              FLASK_STATIC_URL_PATH=/mobile" > .env"
       - run:
           name: Generate GAE app.yaml file
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
           key: react-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - run:
+          name: Build React App
+          command: yarn build
 
 
   build-flask:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,6 @@ jobs:
           name: Set hompage in package.json
           command: |
             sed -i 's|"homepage": "http://localhost:3000/"|"homepage": "https://'$URL'/mobile"|' package.json
-      - run:
-          name: print package.json
-          command: |
-            cat package.json
       # following https://circleci.com/docs/2.0/yarn/
       - restore_cache:
           name: Restore Yarn Package Cache
@@ -142,7 +138,7 @@ jobs:
               MYSQL_PASSWORD=${DB_PASS}
               MYSQL_DB=${DB_NAME}
               MYSQL_SOCKET=${DB_SOCKET}
-              FLASK_STATIC_FOLDER=../react
+              FLASK_STATIC_FOLDER=../react-build
               FLASK_STATIC_URL_PATH=/mobile" > .env
       - run:
           name: Generate GAE app.yaml file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,20 @@ version: 2.1
 orbs:
   gcp-cli: circleci/gcp-cli@1.8.4
 jobs:
+  build-react:
+    docker:
+      - image: circleci/python:3.8-buster-node
+    working_directory: ~/react
+    steps:
+      - run:
+          name: Clone React Repo
+          command: |
+            cd ..
+            git clone --branch master https://github.com/boxwise/boxwise-react.git react
+            ls -al
+      - run: ls -al
+
+
   build-flask:
     docker:
       - image: circleci/python:3.8-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,32 @@ version: 2.1
 orbs:
   gcp-cli: circleci/gcp-cli@1.8.4
 jobs:
+  build-flask:
+    docker:
+      - image: circleci/python:3.8-buster
+    working_directory: ~/flask
+    steps:
+      - checkout
+      # Restore cached dependencies
+      - restore_cache:
+          key: flask-deps-{{ checksum "requirements.txt" }}
+      - run:
+          name: create the python virtual environment and install non-cached dependencies
+          command: |
+            python3 -m venv env
+            source env/bin/activate
+            pip install . -r requirements.txt
+      # Cache the installed packages
+      - save_cache:
+          key: flask-deps-{{ checksum "requirements.txt" }}
+          paths:
+            - env
+      # save build to a CircleCI workspace
+      - persist_to_workspace:
+          root: ~/flask
+          paths:
+            - .
+
   build-react:
     docker:
       - image: circleci/python:3.8-buster-node
@@ -37,34 +63,14 @@ jobs:
             - ~/.cache/yarn
       - run:
           name: Build React App
-          command: yarn build
-
-
-  build-flask:
-    docker:
-      - image: circleci/python:3.8-buster
-    working_directory: ~/flask
-    steps:
-      - checkout
-      # Restore cached dependencies
-      - restore_cache:
-          key: flask-deps-{{ checksum "requirements.txt" }}
-      - run:
-          name: create the python virtual environment and install non-cached dependencies
           command: |
-            python3 -m venv env
-            source env/bin/activate
-            pip install . -r requirements.txt
-      # Cache the installed packages
-      - save_cache:
-          key: flask-deps-{{ checksum "requirements.txt" }}
-          paths:
-            - env
-      # save build to a CircleCI workspace
+            yarn build
+            mv build react-build
+      # Add build to workspace
       - persist_to_workspace:
-          root: ~/flask
+          root: ~/react
           paths:
-            - .
+            - react-build
 
   # following https://circleci.com/docs/2.0/project-walkthrough/
   test-flask:
@@ -141,14 +147,24 @@ jobs:
           name: Deploy to GAE
           command: |
             gcloud app deploy app-<< parameters.serviceName >>.yaml
+
+
 workflows:
   build-and-deploy:
     jobs:
-    - build-react
     - build-flask
+
     - test-flask:
         requires:
           - build-flask
+
+    - build-react:
+        name: build-react-for-staging
+        context: STAGING
+        filters:
+          branches:
+            only: circleci/add_frontend
+
     # deploy to staging
     - deploy:
         name: deploy-staging
@@ -156,9 +172,11 @@ workflows:
         serviceName: api-staging
         requires:
           - test-flask
+          - build-react-for-staging
         filters:
           branches:
-            only: master
+            only: circleci/add_frontend
+
     # deploy to demo
     - deploy:
         name: deploy-demo
@@ -167,6 +185,7 @@ workflows:
         filters:
           branches:
             only: production
+
     # deploy to production
     - deploy:
         name: deploy-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ workflows:
         context: STAGING
         filters:
           branches:
-            only: circleci/add_frontend
+            only: master
 
     # deploy to staging
     - deploy:
@@ -181,7 +181,7 @@ workflows:
           - build-react-for-staging
         filters:
           branches:
-            only: circleci/add_frontend
+            only: master
 
     # deploy to demo
     - deploy:
@@ -200,3 +200,37 @@ workflows:
         filters:
           branches:
             only: production
+  # nightly workflow to deploy master from React each night
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build-flask
+
+      - test-flask:
+          requires:
+            - build-flask
+
+      - build-react:
+          name: build-react-for-staging
+          context: STAGING
+          filters:
+            branches:
+              only: master
+
+      # deploy to staging
+      - deploy:
+          name: deploy-staging
+          context: STAGING
+          serviceName: api-staging
+          requires:
+            - test-flask
+            - build-react-for-staging
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             cd ..
             git clone --branch master https://github.com/boxwise/boxwise-react.git react
       - run:
-          name: Generate .env file
+          name: Generate .env File
           command: |
             echo "
               REACT_APP_AUTH0_DOMAIN=${AUTH0_DOMAIN}
@@ -22,6 +22,19 @@ jobs:
               REACT_APP_REDIRECT=${REACT_APP_REDIRECT}
               REACT_APP_LOGOUT_URL=${REACT_APP_LOGOUT_URL}
               REACT_APP_GRAPHQL_SERVER=${REACT_APP_GRAPHQL_SERVER}" > .env
+      # following https://circleci.com/docs/2.0/yarn/
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - react-yarn-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install Yarn Packages
+          command: yarn install --immutable
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: react-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
 
 
   build-flask:
@@ -32,7 +45,7 @@ jobs:
       - checkout
       # Restore cached dependencies
       - restore_cache:
-          key: deps-{{ checksum "requirements.txt" }}
+          key: flask-deps-{{ checksum "requirements.txt" }}
       - run:
           name: create the python virtual environment and install non-cached dependencies
           command: |
@@ -41,7 +54,7 @@ jobs:
             pip install . -r requirements.txt
       # Cache the installed packages
       - save_cache:
-          key: deps-{{ checksum "requirements.txt" }}
+          key: flask-deps-{{ checksum "requirements.txt" }}
           paths:
             - env
       # save build to a CircleCI workspace
@@ -60,14 +73,14 @@ jobs:
       - attach_workspace:
           at: .
       - restore_cache:
-          key: dev-deps-{{ checksum "requirements-dev.txt" }}
+          key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
       - run:
           name: install dev dependencies for linting and testing
           command: |
             source env/bin/activate
             pip install -r requirements-dev.txt
       - save_cache:
-          key: dev-deps-{{ checksum "requirements-dev.txt" }}
+          key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
           paths:
             - env
       # run linting checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,17 +85,17 @@ jobs:
       # Attach workspace from build
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
+      # - restore_cache:
+      #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
       - run:
           name: install dev dependencies for linting and testing
           command: |
             source env/bin/activate
             pip install -r requirements-dev.txt
-      - save_cache:
-          key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
-          paths:
-            - env
+      # - save_cache:
+      #     key: flask-dev-deps-{{ checksum "requirements-dev.txt" }}
+      #     paths:
+      #       - env
       # run linting checks
       # run tests https://circleci.com/docs/2.0/collect-test-data/#pytest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,10 @@ jobs:
           name: Set hompage in package.json
           command: |
             sed -i 's|"homepage": "http://localhost:3000/"|"homepage": "https://'$URL'/mobile"|' package.json
+      - run:
+          name: print package.json
+          command: |
+            cat package.json
       # following https://circleci.com/docs/2.0/yarn/
       - restore_cache:
           name: Restore Yarn Package Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
               REACT_APP_REDIRECT=${REACT_APP_REDIRECT}
               REACT_APP_LOGOUT_URL=${REACT_APP_LOGOUT_URL}
               REACT_APP_GRAPHQL_SERVER=${REACT_APP_GRAPHQL_SERVER}" > .env
-s
 
 
   build-flask:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,17 @@ jobs:
           command: |
             cd ..
             git clone --branch master https://github.com/boxwise/boxwise-react.git react
-            ls -al
-      - run: ls -al
+      - run:
+          name: Generate .env file
+          command: |
+            echo "
+              REACT_APP_AUTH0_DOMAIN=${AUTH0_DOMAIN}
+              REACT_APP_AUTH0_CLIENT_ID=${REACT_APP_AUTH0_CLIENT_ID}
+              REACT_APP_AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
+              REACT_APP_REDIRECT=${REACT_APP_REDIRECT}
+              REACT_APP_LOGOUT_URL=${REACT_APP_LOGOUT_URL}
+              REACT_APP_GRAPHQL_SERVER=${REACT_APP_GRAPHQL_SERVER}" > .env
+s
 
 
   build-flask:
@@ -98,12 +107,12 @@ jobs:
           name: Generate .env file
           command: |
             echo "
-            AUTH0_DOMAIN=${AUTH0_DOMAIN}
-            AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
-            MYSQL_USER=${DB_NAME}
-            MYSQL_PASSWORD=${DB_PASS}
-            MYSQL_DB=${DB_NAME}
-            GCLOUD_SQL_CONNECTION_NAME=${GCLOUD_SQL_CONNECTION_NAME}" > .env
+              AUTH0_DOMAIN=${AUTH0_DOMAIN}
+              AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
+              MYSQL_USER=${DB_NAME}
+              MYSQL_PASSWORD=${DB_PASS}
+              MYSQL_DB=${DB_NAME}
+              GCLOUD_SQL_CONNECTION_NAME=${GCLOUD_SQL_CONNECTION_NAME}" > .env
       - run:
           name: Generate GAE app.yaml file
           command: |
@@ -120,6 +129,7 @@ jobs:
 workflows:
   build-and-deploy:
     jobs:
+    - build-react
     - build-flask
     - test-flask:
         requires:

--- a/boxwise_flask/app.py
+++ b/boxwise_flask/app.py
@@ -1,9 +1,16 @@
 """Configuration and instantiation of flask app and peewee-managed database"""
+import os
+
 from flask import Flask
 from flask_cors import CORS
 from playhouse.flask_utils import FlaskDB
 
-app = Flask(__name__)
+# Not able to change the static folder variables after app is initialized
+app = Flask(
+    __name__,
+    static_folder=os.getenv("FLASK_STATIC_FOLDER", "static"),
+    static_url_path=os.getenv("FLASK_STATIC_URL_PATH", "/static"),
+)
 CORS(app)
 
 db = FlaskDB()

--- a/boxwise_flask/main.py
+++ b/boxwise_flask/main.py
@@ -4,23 +4,18 @@ import os
 from .app import db
 from .routes import app
 
-# load data for database connection
-db_user = os.getenv("MYSQL_USER")
-db_password = os.getenv("MYSQL_PASSWORD")
-db_name = os.getenv("MYSQL_DB")
-db_host = os.getenv("MYSQL_HOST")
-# int, otherwise: TypeError: %d format: a number is required, not str from
-# pymysql.connections
-db_port = int(os.getenv("MYSQL_PORT", 0))
-gcloud_sql_connection_name = os.getenv("GCLOUD_SQL_CONNECTION_NAME", False)
+# Prepare address of mysql host
+mysql_host = os.getenv("MYSQL_HOST", "") + (
+    ":" + os.getenv("MYSQL_PORT") if os.getenv("MYSQL_PORT", False) else ""
+)
 
-if gcloud_sql_connection_name:
-    app.config["DATABASE"] = "mysql://{}:{}@/{}?unix_socket=/cloudsql/{}".format(
-        db_user, db_password, db_name, gcloud_sql_connection_name
-    )
-else:
-    app.config["DATABASE"] = "mysql://{}:{}@{}:{}/{}".format(
-        db_user, db_password, db_host, db_port, db_name
-    )
+# establish database connection
+app.config["DATABASE"] = "mysql://{}:{}@{}/{}{}".format(
+    os.getenv("MYSQL_USER"),
+    os.getenv("MYSQL_PASSWORD"),
+    mysql_host,
+    os.getenv("MYSQL_DB"),
+    os.getenv("MYSQL_SOCKET", ""),
+)
 
 db.init_app(app)

--- a/boxwise_flask/routes.py
+++ b/boxwise_flask/routes.py
@@ -21,6 +21,11 @@ def HELLO():
     return "This is a landing page"
 
 
+@app.route("/mobile")
+def index():
+    return app.send_static_file("index.html")
+
+
 # This doesn't need authentication
 @app.route("/api/public")
 @cross_origin(origin="localhost", headers=["Content-Type", "Authorization"])

--- a/boxwise_flask/routes.py
+++ b/boxwise_flask/routes.py
@@ -21,6 +21,7 @@ def HELLO():
     return "This is a landing page"
 
 
+# Serving React on production
 @app.route("/mobile")
 def index():
     return app.send_static_file("index.html")


### PR DESCRIPTION
The current CircleCI config clones the [frontend](https://github.com/boxwise/boxwise-react) now as well and deploys them together to the same App Engine service. 
This was the easiest and quickest solution to get FE/BE deployed continuously.

Since we are planning to merge the repos anyway (#17) this should not create much extra work in the future.
@jamescrowley I would like to hear your opinion if React and Flask should be run on the same Google App Engine service when we are ready for a real production environment.

The url of the BE is
https://api-staging-dot-dropapp-242214.ew.r.appspot.com/ 

All endpoints are located at 
https://api-staging-dot-dropapp-242214.ew.r.appspot.com/api/.....

The FE can be reached at 
https://api-staging-dot-dropapp-242214.ew.r.appspot.com/mobile

Since the two repos are not merged yet and changes to master in the FE repo do not trigger a new deploy, I created a nightly CircleCI workflow so that each night at 5 am CEST the master branch of both repos is deployed to staging. 
